### PR TITLE
Bring up to 1.5 ts level

### DIFF
--- a/src/main/kotlin/dev/sailhouse/AdminClient.kt
+++ b/src/main/kotlin/dev/sailhouse/AdminClient.kt
@@ -1,0 +1,70 @@
+package dev.sailhouse
+
+import dev.sailhouse.models.*
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.*
+
+/**
+ * Admin client for managing Sailhouse resources.
+ *
+ * @param httpClient The HTTP client for making requests.
+ * @param baseUrl The base URL for the Sailhouse API.
+ */
+class AdminClient(
+    private val httpClient: HttpClient,
+    private val baseUrl: String
+) {
+    /**
+     * Registers a push subscription.
+     *
+     * @param topic The topic to subscribe to.
+     * @param subscription The subscription name.
+     * @param endpoint The endpoint URL for push notifications.
+     * @param options Additional options for the subscription.
+     * @return The registration result.
+     */
+    suspend fun registerPushSubscription(
+        topic: String,
+        subscription: String,
+        endpoint: String,
+        options: PushSubscriptionOptions? = null
+    ): RegisterResult {
+        return withContext(Dispatchers.IO) {
+            val requestBody = buildJsonObject {
+                put("type", "push")
+                put("endpoint", endpoint)
+                options?.filter?.let { filter ->
+                    when (filter) {
+                        is ComplexFilter -> {
+                            put("filter", buildJsonObject {
+                                put("filters", buildJsonArray {
+                                    filter.filters.forEach { condition ->
+                                        add(buildJsonObject {
+                                            put("path", condition.path)
+                                            put("condition", condition.condition)
+                                            put("value", condition.value)
+                                        })
+                                    }
+                                })
+                                put("operator", filter.operator)
+                            })
+                        }
+                        is Boolean -> put("filter", filter)
+                        null -> put("filter", JsonNull)
+                    }
+                }
+                options?.rateLimit?.let { put("rate_limit", it) }
+                options?.deduplication?.let { put("deduplication", it) }
+            }
+
+            httpClient.put("$baseUrl/api/v1/topics/$topic/subscriptions/$subscription") {
+                setBody(requestBody)
+            }.body()
+        }
+    }
+}

--- a/src/main/kotlin/dev/sailhouse/Event.kt
+++ b/src/main/kotlin/dev/sailhouse/Event.kt
@@ -3,6 +3,7 @@ package dev.sailhouse
 import dev.sailhouse.models.EventDto
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.JsonElement
 
 /**
  * Represents an event in the Sailhouse system.
@@ -11,6 +12,7 @@ import kotlinx.coroutines.withContext
  * @param data The data payload of the event.
  * @param queryableValue The value that can be queried.
  * @param timestamp The timestamp when the event was created.
+ * @param metadata Additional metadata associated with the event.
  * @param topic The topic the event belongs to.
  * @param subscription The subscription the event was retrieved from.
  * @param client The Sailhouse client instance.
@@ -20,6 +22,7 @@ class Event<T>(
     val data: T,
     val queryableValue: String,
     val timestamp: String,
+    val metadata: Map<String, JsonElement>? = null,
     private val topic: String,
     private val subscription: String,
     private val client: SailhouseClient
@@ -54,6 +57,7 @@ class Event<T>(
                 data = dto.data,
                 queryableValue = dto.queryableValue,
                 timestamp = dto.timestamp,
+                metadata = dto.metadata,
                 topic = topic,
                 subscription = subscription,
                 client = client

--- a/src/main/kotlin/dev/sailhouse/PushSubscriptionVerifier.kt
+++ b/src/main/kotlin/dev/sailhouse/PushSubscriptionVerifier.kt
@@ -1,0 +1,246 @@
+package dev.sailhouse
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.util.*
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+import kotlin.math.abs
+
+/**
+ * Exception thrown when push subscription signature verification fails.
+ */
+class PushSubscriptionVerificationException(
+    message: String,
+    val code: String
+) : Exception(message)
+
+/**
+ * Parsed signature header components.
+ */
+data class SignatureComponents(
+    val timestamp: Long,
+    val signature: String
+)
+
+/**
+ * Headers expected from a push subscription request.
+ */
+data class PushSubscriptionHeaders(
+    val sailhouseSignature: String,
+    val identifier: String,
+    val eventId: String
+)
+
+/**
+ * Push subscription payload structure.
+ */
+@Serializable
+data class PushSubscriptionPayload<T>(
+    val data: T,
+    val metadata: Map<String, JsonElement>? = null,
+    val id: String,
+    val timestamp: String
+)
+
+/**
+ * Verification options.
+ */
+data class VerificationOptions(
+    val tolerance: Long = 300 // tolerance in seconds
+)
+
+/**
+ * Push subscription signature verifier.
+ */
+class PushSubscriptionVerifier(private val secret: String) {
+
+    init {
+        require(secret.isNotBlank()) { "Push subscription secret is required" }
+    }
+
+    /**
+     * Verifies a push subscription signature.
+     *
+     * @param signature The Sailhouse-Signature header value.
+     * @param body The raw request body as string.
+     * @param options Verification options.
+     * @return true if signature is valid.
+     * @throws PushSubscriptionVerificationException if verification fails.
+     */
+    fun verifySignature(
+        signature: String,
+        body: String,
+        options: VerificationOptions = VerificationOptions()
+    ): Boolean {
+        try {
+            // Parse signature header
+            val (timestamp, headerSignature) = parseSignatureHeader(signature)
+
+            // Validate timestamp
+            if (!isTimestampValid(timestamp, options.tolerance)) {
+                throw PushSubscriptionVerificationException(
+                    "Request timestamp is too old. Maximum age: ${options.tolerance} seconds",
+                    "TIMESTAMP_TOO_OLD"
+                )
+            }
+
+            // Calculate expected signature
+            val expectedSignature = calculateSignature(timestamp, body)
+
+            // Perform constant-time comparison
+            if (!constantTimeEqual(expectedSignature, headerSignature)) {
+                throw PushSubscriptionVerificationException(
+                    "Signature verification failed",
+                    "INVALID_SIGNATURE"
+                )
+            }
+
+            return true
+        } catch (e: PushSubscriptionVerificationException) {
+            throw e
+        } catch (e: Exception) {
+            throw PushSubscriptionVerificationException(
+                "Signature verification failed: ${e.message}",
+                "VERIFICATION_ERROR"
+            )
+        }
+    }
+
+    /**
+     * Parses the Sailhouse-Signature header.
+     *
+     * @param header The signature header value.
+     * @return Parsed timestamp and signature.
+     */
+    private fun parseSignatureHeader(header: String): SignatureComponents {
+        if (header.isBlank()) {
+            throw PushSubscriptionVerificationException(
+                "Signature header is required",
+                "MISSING_SIGNATURE_HEADER"
+            )
+        }
+
+        val elements = header.split(",")
+        var timestamp: Long? = null
+        var signature: String? = null
+
+        for (element in elements) {
+            val trimmed = element.trim()
+            val parts = trimmed.split("=", limit = 2)
+            if (parts.size != 2) continue
+
+            val (key, value) = parts
+            when (key) {
+                "t" -> {
+                    timestamp = value.toLongOrNull()
+                        ?: throw PushSubscriptionVerificationException(
+                            "Invalid timestamp in signature header",
+                            "INVALID_TIMESTAMP"
+                        )
+                }
+                "v1" -> {
+                    signature = value
+                }
+            }
+        }
+
+        if (timestamp == null || signature == null) {
+            throw PushSubscriptionVerificationException(
+                "Invalid signature header format. Expected format: t=<timestamp>,v1=<signature>",
+                "INVALID_SIGNATURE_FORMAT"
+            )
+        }
+
+        return SignatureComponents(timestamp, signature)
+    }
+
+    /**
+     * Checks if timestamp is within tolerance.
+     *
+     * @param timestamp The timestamp to validate.
+     * @param tolerance Maximum age in seconds.
+     * @return true if timestamp is valid.
+     */
+    private fun isTimestampValid(timestamp: Long, tolerance: Long): Boolean {
+        val currentTime = System.currentTimeMillis() / 1000
+        return abs(currentTime - timestamp) <= tolerance
+    }
+
+    /**
+     * Calculates HMAC-SHA256 signature for the payload.
+     *
+     * @param timestamp The timestamp from the signature header.
+     * @param body The raw request body.
+     * @return Hex-encoded signature.
+     */
+    private fun calculateSignature(timestamp: Long, body: String): String {
+        val payload = "$timestamp.$body"
+        val mac = Mac.getInstance("HmacSHA256")
+        val secretKeySpec = SecretKeySpec(secret.toByteArray(StandardCharsets.UTF_8), "HmacSHA256")
+        mac.init(secretKeySpec)
+        val hash = mac.doFinal(payload.toByteArray(StandardCharsets.UTF_8))
+        return hash.joinToString("") { "%02x".format(it) }
+    }
+
+    /**
+     * Performs constant-time comparison to prevent timing attacks.
+     *
+     * @param expected The expected signature.
+     * @param actual The actual signature from header.
+     * @return true if signatures match.
+     */
+    private fun constantTimeEqual(expected: String, actual: String): Boolean {
+        if (expected.length != actual.length) return false
+        
+        var result = 0
+        for (i in expected.indices) {
+            result = result or (expected[i].code xor actual[i].code)
+        }
+        return result == 0
+    }
+}
+
+/**
+ * Convenience function for one-off signature verification.
+ *
+ * @param secret The push subscription secret.
+ * @param signature The Sailhouse-Signature header value.
+ * @param body The raw request body as string.
+ * @param options Verification options.
+ * @return true if signature is valid.
+ * @throws PushSubscriptionVerificationException if verification fails.
+ */
+fun verifyPushSubscriptionSignature(
+    secret: String,
+    signature: String,
+    body: String,
+    options: VerificationOptions = VerificationOptions()
+): Boolean {
+    val verifier = PushSubscriptionVerifier(secret)
+    return verifier.verifySignature(signature, body, options)
+}
+
+/**
+ * Safe verification that returns a boolean instead of throwing.
+ *
+ * @param secret The push subscription secret.
+ * @param signature The Sailhouse-Signature header value.
+ * @param body The raw request body as string.
+ * @param options Verification options.
+ * @return true if signature is valid, false otherwise.
+ */
+fun verifyPushSubscriptionSignatureSafe(
+    secret: String,
+    signature: String,
+    body: String,
+    options: VerificationOptions = VerificationOptions()
+): Boolean {
+    return try {
+        verifyPushSubscriptionSignature(secret, signature, body, options)
+    } catch (e: Exception) {
+        false
+    }
+}

--- a/src/main/kotlin/dev/sailhouse/SailhouseClient.kt
+++ b/src/main/kotlin/dev/sailhouse/SailhouseClient.kt
@@ -30,6 +30,11 @@ class SailhouseClient(
     private val config: SailhouseClientConfig = SailhouseClientConfig()
 ) : CoroutineScope {
     override val coroutineContext: CoroutineContext = SupervisorJob() + Dispatchers.IO
+    
+    /**
+     * Admin client for managing Sailhouse resources.
+     */
+    val admin: AdminClient
 
     private val json = Json {
         ignoreUnknownKeys = true
@@ -52,6 +57,10 @@ class SailhouseClient(
             connectTimeoutMillis = config.timeout
             socketTimeoutMillis = config.timeout
         }
+    }
+
+    init {
+        admin = AdminClient(httpClient, config.baseUrl)
     }
 
     /**
@@ -79,6 +88,9 @@ class SailhouseClient(
                 }
                 options?.sendAt?.let { sendAt ->
                     put("send_at", sendAt.toString())
+                }
+                options?.waitGroupInstanceId?.let { waitGroupInstanceId ->
+                    put("wait_group_instance_id", waitGroupInstanceId)
                 }
             }
 
@@ -182,6 +194,32 @@ class SailhouseClient(
     }
 
     /**
+     * Pulls a single event from a subscription.
+     *
+     * @param topic The topic to pull from.
+     * @param subscription The subscription to pull from.
+     * @return The event, or null if no events are available.
+     */
+    suspend inline fun <reified T> pull(
+        topic: String,
+        subscription: String
+    ): Event<T>? {
+        return withContext(Dispatchers.IO) {
+            try {
+                val response = httpClient.get("${config.baseUrl}/topics/$topic/subscriptions/$subscription/events/pull")
+                if (response.status.isSuccess()) {
+                    val eventDto = response.body<EventDto<T>>()
+                    Event.fromDto(eventDto, topic, subscription, this@SailhouseClient)
+                } else {
+                    null
+                }
+            } catch (e: Exception) {
+                null
+            }
+        }
+    }
+
+    /**
      * Acknowledges an event.
      *
      * @param topic The topic the event belongs to.
@@ -195,6 +233,47 @@ class SailhouseClient(
     ) {
         withContext(Dispatchers.IO) {
             httpClient.post("${config.baseUrl}/topics/$topic/subscriptions/$subscription/events/$eventId")
+        }
+    }
+
+    /**
+     * Creates a wait group for coordinated publishing of multiple events.
+     *
+     * @param topic The topic for the wait group.
+     * @param events The events to publish as part of the wait group.
+     * @param options The options for the wait group.
+     */
+    suspend fun <T> wait(
+        topic: String,
+        events: List<WaitGroupEvent<T>>,
+        options: WaitOptions? = null
+    ) {
+        withContext(Dispatchers.IO) {
+            // Create wait group instance
+            val waitGroupResponse = httpClient.post("${config.baseUrl}/waitgroups/instances") {
+                setBody(buildJsonObject {
+                    put("topic", topic)
+                    options?.ttl?.let { put("ttl", it) }
+                })
+            }.body<WaitGroupInstanceResponse>()
+
+            // Publish all events with the wait group instance ID
+            events.forEach { event ->
+                publish(
+                    event.topic,
+                    event.body,
+                    PublishEventOptions(
+                        metadata = event.metadata,
+                        sendAt = event.sendAt,
+                        waitGroupInstanceId = waitGroupResponse.waitGroupInstanceId
+                    )
+                )
+            }
+
+            // Mark wait group as in progress
+            httpClient.put("${config.baseUrl}/waitgroups/instances/${waitGroupResponse.waitGroupInstanceId}/events") {
+                setBody(buildJsonObject {})
+            }
         }
     }
 

--- a/src/main/kotlin/dev/sailhouse/SailhouseSubscriber.kt
+++ b/src/main/kotlin/dev/sailhouse/SailhouseSubscriber.kt
@@ -1,0 +1,151 @@
+package dev.sailhouse
+
+import kotlinx.coroutines.*
+import mu.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Options for configuring the subscriber.
+ *
+ * @param perSubscriptionProcessors Number of concurrent processors per subscription.
+ */
+data class SubscriberOptions(
+    val perSubscriptionProcessors: Int = 1
+)
+
+/**
+ * Handler for processing subscription events.
+ */
+typealias SubscriptionHandler<T> = suspend (SubscriptionEvent<T>) -> Unit
+
+/**
+ * Event wrapper for subscription handlers.
+ *
+ * @param event The event to process.
+ */
+data class SubscriptionEvent<T>(
+    val event: Event<T>
+)
+
+/**
+ * Subscription configuration.
+ */
+private data class Subscription<T>(
+    val topic: String,
+    val subscription: String,
+    val handler: SubscriptionHandler<T>
+)
+
+/**
+ * Long-running subscriber for processing events from multiple subscriptions.
+ *
+ * @param client The Sailhouse client.
+ * @param options Configuration options for the subscriber.
+ */
+class SailhouseSubscriber(
+    private val client: SailhouseClient,
+    private val options: SubscriberOptions = SubscriberOptions()
+) {
+    private val subscriptions = mutableListOf<Subscription<*>>()
+    private var isRunning = false
+    private var activeJobs = mutableListOf<Job>()
+
+    /**
+     * Subscribes to a topic/subscription with a handler.
+     *
+     * @param topic The topic to subscribe to.
+     * @param subscription The subscription name.
+     * @param handler The handler for processing events.
+     */
+    fun <T> subscribe(
+        topic: String,
+        subscription: String,
+        handler: SubscriptionHandler<T>
+    ) {
+        subscriptions.add(Subscription(topic, subscription, handler))
+    }
+
+    /**
+     * Starts processing events from all subscriptions.
+     */
+    suspend fun start() {
+        if (isRunning) {
+            throw IllegalStateException("Subscriber is already running")
+        }
+
+        isRunning = true
+        logger.info { "Starting subscriber with ${subscriptions.size} subscriptions" }
+
+        activeJobs = subscriptions.flatMap { subscription ->
+            (1..options.perSubscriptionProcessors).map {
+                CoroutineScope(Dispatchers.IO).launch {
+                    runSubscriberLoop(subscription)
+                }
+            }
+        }.toMutableList()
+
+        // Wait for all jobs to complete
+        activeJobs.joinAll()
+    }
+
+    /**
+     * Stops the subscriber.
+     */
+    fun stop() {
+        logger.info { "Stopping subscriber" }
+        isRunning = false
+        activeJobs.forEach { it.cancel() }
+        activeJobs.clear()
+    }
+
+    /**
+     * Runs the event processing loop for a single subscription.
+     */
+    private suspend fun <T> runSubscriberLoop(subscription: Subscription<T>) {
+        val topic = subscription.topic
+        val subscriptionName = subscription.subscription
+        val handler = subscription.handler
+
+        logger.info { "Starting processor for $topic/$subscriptionName" }
+
+        while (isRunning) {
+            try {
+                // Pull an event from the subscription
+                val event = client.pull<T>(topic, subscriptionName)
+
+                if (event != null) {
+                    try {
+                        // Handle the event
+                        handler(SubscriptionEvent(event))
+                        
+                        // Acknowledge the event
+                        event.ack()
+                    } catch (handlerError: Exception) {
+                        logger.error(handlerError) {
+                            "Error handling event ${event.id} from $topic/$subscriptionName"
+                        }
+                    }
+                } else {
+                    // No events available, wait before trying again
+                    delay(1000)
+                }
+            } catch (pullError: Exception) {
+                logger.error(pullError) { "Error pulling from $topic/$subscriptionName" }
+                delay(1000)
+            }
+        }
+
+        logger.info { "Stopped processor for $topic/$subscriptionName" }
+    }
+}
+
+/**
+ * Creates a new subscriber instance.
+ *
+ * @param options Configuration options for the subscriber.
+ * @return A new SailhouseSubscriber instance.
+ */
+fun SailhouseClient.subscriber(options: SubscriberOptions = SubscriberOptions()): SailhouseSubscriber {
+    return SailhouseSubscriber(this, options)
+}

--- a/src/main/kotlin/dev/sailhouse/models/Models.kt
+++ b/src/main/kotlin/dev/sailhouse/models/Models.kt
@@ -1,6 +1,7 @@
 package dev.sailhouse.models
 
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
@@ -21,7 +22,8 @@ data class EventDto<T>(
     val id: String,
     val data: T,
     val queryableValue: String,
-    val timestamp: String
+    val timestamp: String,
+    val metadata: Map<String, JsonElement>? = null
 )
 
 /**
@@ -53,12 +55,14 @@ data class PublishEventResponseDto(
  *
  * @param metadata Additional metadata for the event.
  * @param sendAt The time to send the event.
+ * @param waitGroupInstanceId The wait group instance ID for coordinated publishing.
  */
 @Serializable
 data class PublishEventOptions(
     val metadata: Map<String, String>? = null,
     @Serializable(with = InstantSerializer::class)
-    val sendAt: Instant? = null
+    val sendAt: Instant? = null,
+    val waitGroupInstanceId: String? = null
 )
 
 /**
@@ -71,6 +75,94 @@ data class PublishEventOptions(
 data class GetEventOptions(
     val timeWindow: String? = null,
     val queryablePath: String? = null
+)
+
+/**
+ * Options for wait group creation.
+ *
+ * @param ttl The time-to-live for the wait group.
+ */
+@Serializable
+data class WaitOptions(
+    val ttl: String? = null
+)
+
+/**
+ * Response from creating a wait group instance.
+ *
+ * @param waitGroupInstanceId The unique identifier for the wait group instance.
+ */
+@Serializable
+data class WaitGroupInstanceResponse(
+    @SerialName("wait_group_instance_id")
+    val waitGroupInstanceId: String
+)
+
+/**
+ * Event to be published as part of a wait group.
+ *
+ * @param topic The topic to publish to.
+ * @param body The event data.
+ * @param metadata Additional metadata for the event.
+ * @param sendAt The time to send the event.
+ */
+@Serializable
+data class WaitGroupEvent<T>(
+    val topic: String,
+    val body: T,
+    val metadata: Map<String, String>? = null,
+    @Serializable(with = InstantSerializer::class)
+    val sendAt: Instant? = null
+)
+
+/**
+ * Filter condition for complex filtering.
+ *
+ * @param path The path to filter on.
+ * @param condition The condition to apply.
+ * @param value The value to compare against.
+ */
+@Serializable
+data class FilterCondition(
+    val path: String,
+    val condition: String,
+    val value: String
+)
+
+/**
+ * Complex filter with multiple conditions.
+ *
+ * @param filters The list of filter conditions.
+ * @param operator The operator to apply between conditions.
+ */
+@Serializable
+data class ComplexFilter(
+    val filters: List<FilterCondition>,
+    val operator: String
+)
+
+/**
+ * Options for push subscription registration.
+ *
+ * @param filter The filter to apply to events.
+ * @param rateLimit The rate limit configuration.
+ * @param deduplication The deduplication configuration.
+ */
+@Serializable
+data class PushSubscriptionOptions(
+    val filter: Any? = null, // Can be Boolean, ComplexFilter, or null
+    val rateLimit: String? = null,
+    val deduplication: String? = null
+)
+
+/**
+ * Result of subscription registration.
+ *
+ * @param outcome The outcome of the registration.
+ */
+@Serializable
+data class RegisterResult(
+    val outcome: String // "created", "updated", or "none"
 )
 
 /**

--- a/src/test/kotlin/dev/sailhouse/AdminClientTest.kt
+++ b/src/test/kotlin/dev/sailhouse/AdminClientTest.kt
@@ -1,0 +1,85 @@
+package dev.sailhouse
+
+import dev.sailhouse.models.*
+import io.ktor.client.engine.mock.*
+import io.ktor.http.*
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AdminClientTest {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        encodeDefaults = true
+    }
+
+    private val mockEngine = MockEngine { request ->
+        when {
+            request.url.encodedPath.contains("/api/v1/topics/") && 
+            request.url.encodedPath.contains("/subscriptions/") -> {
+                val response = RegisterResult(outcome = "created")
+                respond(
+                    content = json.encodeToString(response),
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json")
+                )
+            }
+            else -> {
+                respond(
+                    content = "Not found",
+                    status = HttpStatusCode.NotFound
+                )
+            }
+        }
+    }
+
+    private val config = SailhouseClientConfig(
+        baseUrl = "https://api.sailhouse.dev",
+        engine = mockEngine
+    )
+
+    private val client = SailhouseClient("test-api-key", config)
+
+    @Test
+    fun `test register push subscription`() = runBlocking {
+        val result = client.admin.registerPushSubscription(
+            topic = "test-topic",
+            subscription = "test-subscription",
+            endpoint = "https://example.com/webhook"
+        )
+
+        assertEquals("created", result.outcome)
+    }
+
+    @Test
+    fun `test register push subscription with filter`() = runBlocking {
+        val filter = ComplexFilter(
+            filters = listOf(
+                FilterCondition(
+                    path = "data.type",
+                    condition = "eq",
+                    value = "order"
+                )
+            ),
+            operator = "and"
+        )
+
+        val options = PushSubscriptionOptions(
+            filter = filter,
+            rateLimit = "10/minute",
+            deduplication = "5m"
+        )
+
+        val result = client.admin.registerPushSubscription(
+            topic = "test-topic",
+            subscription = "test-subscription",
+            endpoint = "https://example.com/webhook",
+            options = options
+        )
+
+        assertEquals("created", result.outcome)
+    }
+}

--- a/src/test/kotlin/dev/sailhouse/PushSubscriptionVerifierTest.kt
+++ b/src/test/kotlin/dev/sailhouse/PushSubscriptionVerifierTest.kt
@@ -1,0 +1,119 @@
+package dev.sailhouse
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PushSubscriptionVerifierTest {
+    private val secret = "test-secret"
+    private val verifier = PushSubscriptionVerifier(secret)
+
+    @Test
+    fun `test valid signature verification`() {
+        val timestamp = System.currentTimeMillis() / 1000
+        val body = """{"data": {"message": "test"}, "id": "123", "timestamp": "2023-01-01T00:00:00Z"}"""
+        
+        // Calculate expected signature manually for testing
+        val payload = "$timestamp.$body"
+        val expectedSignature = calculateHmacSha256(secret, payload)
+        val signature = "t=$timestamp,v1=$expectedSignature"
+
+        assertTrue(verifier.verifySignature(signature, body))
+    }
+
+    @Test
+    fun `test invalid signature verification`() {
+        val timestamp = System.currentTimeMillis() / 1000
+        val body = """{"data": {"message": "test"}, "id": "123", "timestamp": "2023-01-01T00:00:00Z"}"""
+        val signature = "t=$timestamp,v1=invalid_signature"
+
+        assertFailsWith<PushSubscriptionVerificationException> {
+            verifier.verifySignature(signature, body)
+        }
+    }
+
+    @Test
+    fun `test timestamp too old`() {
+        val oldTimestamp = (System.currentTimeMillis() / 1000) - 400 // 400 seconds ago
+        val body = """{"data": {"message": "test"}, "id": "123", "timestamp": "2023-01-01T00:00:00Z"}"""
+        val payload = "$oldTimestamp.$body"
+        val expectedSignature = calculateHmacSha256(secret, payload)
+        val signature = "t=$oldTimestamp,v1=$expectedSignature"
+
+        val exception = assertFailsWith<PushSubscriptionVerificationException> {
+            verifier.verifySignature(signature, body)
+        }
+        assertEquals("TIMESTAMP_TOO_OLD", exception.code)
+    }
+
+    @Test
+    fun `test invalid signature header format`() {
+        val body = """{"data": {"message": "test"}, "id": "123", "timestamp": "2023-01-01T00:00:00Z"}"""
+        val signature = "invalid_format"
+
+        val exception = assertFailsWith<PushSubscriptionVerificationException> {
+            verifier.verifySignature(signature, body)
+        }
+        assertEquals("INVALID_SIGNATURE_FORMAT", exception.code)
+    }
+
+    @Test
+    fun `test missing signature header`() {
+        val body = """{"data": {"message": "test"}, "id": "123", "timestamp": "2023-01-01T00:00:00Z"}"""
+        val signature = ""
+
+        val exception = assertFailsWith<PushSubscriptionVerificationException> {
+            verifier.verifySignature(signature, body)
+        }
+        assertEquals("MISSING_SIGNATURE_HEADER", exception.code)
+    }
+
+    @Test
+    fun `test convenience function`() {
+        val timestamp = System.currentTimeMillis() / 1000
+        val body = """{"data": {"message": "test"}, "id": "123", "timestamp": "2023-01-01T00:00:00Z"}"""
+        val payload = "$timestamp.$body"
+        val expectedSignature = calculateHmacSha256(secret, payload)
+        val signature = "t=$timestamp,v1=$expectedSignature"
+
+        assertTrue(verifyPushSubscriptionSignature(secret, signature, body))
+    }
+
+    @Test
+    fun `test safe verification function`() {
+        val timestamp = System.currentTimeMillis() / 1000
+        val body = """{"data": {"message": "test"}, "id": "123", "timestamp": "2023-01-01T00:00:00Z"}"""
+        val validSignature = "t=$timestamp,v1=${calculateHmacSha256(secret, "$timestamp.$body")}"
+        val invalidSignature = "t=$timestamp,v1=invalid"
+
+        assertTrue(verifyPushSubscriptionSignatureSafe(secret, validSignature, body))
+        assertFalse(verifyPushSubscriptionSignatureSafe(secret, invalidSignature, body))
+    }
+
+    @Test
+    fun `test custom tolerance`() {
+        val oldTimestamp = (System.currentTimeMillis() / 1000) - 200 // 200 seconds ago
+        val body = """{"data": {"message": "test"}, "id": "123", "timestamp": "2023-01-01T00:00:00Z"}"""
+        val payload = "$oldTimestamp.$body"
+        val expectedSignature = calculateHmacSha256(secret, payload)
+        val signature = "t=$oldTimestamp,v1=$expectedSignature"
+
+        // Should fail with default tolerance (300 seconds) - actually this should pass
+        // Let's use 100 seconds tolerance to make it fail
+        val options = VerificationOptions(tolerance = 100)
+        
+        assertFailsWith<PushSubscriptionVerificationException> {
+            verifier.verifySignature(signature, body, options)
+        }
+    }
+
+    private fun calculateHmacSha256(secret: String, data: String): String {
+        val mac = javax.crypto.Mac.getInstance("HmacSHA256")
+        val secretKeySpec = javax.crypto.spec.SecretKeySpec(secret.toByteArray(), "HmacSHA256")
+        mac.init(secretKeySpec)
+        val hash = mac.doFinal(data.toByteArray())
+        return hash.joinToString("") { "%02x".format(it) }
+    }
+}

--- a/src/test/kotlin/dev/sailhouse/SailhouseClientTest.kt
+++ b/src/test/kotlin/dev/sailhouse/SailhouseClientTest.kt
@@ -1,8 +1,8 @@
 package dev.sailhouse
 
-import dev.sailhouse.models.EventDto
-import dev.sailhouse.models.EventsResponseDto
-import dev.sailhouse.models.PublishEventResponseDto
+import dev.sailhouse.models.*
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
 import io.ktor.client.engine.mock.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.http.*
@@ -37,7 +37,11 @@ class SailhouseClientTest {
                         id = "test-event-id",
                         data = mapOf("message" to "Test message"),
                         queryableValue = "Test message",
-                        timestamp = "2023-01-01T00:00:00Z"
+                        timestamp = "2023-01-01T00:00:00Z",
+                        metadata = buildJsonObject {
+                            put("source", JsonPrimitive("test"))
+                            put("version", JsonPrimitive("1.0"))
+                        }
                     )
                 )
                 val response = EventsResponseDto(events = events, offset = 0, limit = 10)
@@ -51,6 +55,22 @@ class SailhouseClientTest {
                 respond(
                     content = "",
                     status = HttpStatusCode.OK
+                )
+            }
+            "/topics/test-topic/subscriptions/test-subscription/events/pull" -> {
+                val event = EventDto(
+                    id = "pulled-event-id",
+                    data = mapOf("message" to "Pulled message"),
+                    queryableValue = "Pulled message",
+                    timestamp = "2023-01-01T00:00:00Z",
+                    metadata = buildJsonObject {
+                        put("pulled", JsonPrimitive("true"))
+                    }
+                )
+                respond(
+                    content = json.encodeToString(event),
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json")
                 )
             }
             else -> {
@@ -90,5 +110,38 @@ class SailhouseClientTest {
     fun `test ack event`() = runBlocking {
         // This should not throw an exception
         client.ackEvent("test-topic", "test-subscription", "test-event-id")
+    }
+
+    @Test
+    fun `test metadata support in events`() = runBlocking {
+        val response = client.getEvents<Map<String, String>>("test-topic", "test-subscription")
+
+        assertEquals(1, response.events.size)
+        val event = response.events[0]
+        assertEquals("test-event-id", event.id)
+        assertNotNull(event.metadata)
+        assertEquals("test", event.metadata?.get("source")?.toString()?.removePrefix("\"")?.removeSuffix("\""))
+    }
+
+    @Test
+    fun `test pull single event`() = runBlocking {
+        val event = client.pull<Map<String, String>>("test-topic", "test-subscription")
+
+        assertNotNull(event)
+        assertEquals("pulled-event-id", event.id)
+        assertEquals("Pulled message", event.data["message"])
+        assertNotNull(event.metadata)
+        assertEquals("true", event.metadata?.get("pulled")?.toString()?.removePrefix("\"")?.removeSuffix("\""))
+    }
+
+    @Test
+    fun `test publish with metadata`() = runBlocking {
+        val event = mapOf("message" to "Test message")
+        val options = PublishEventOptions(
+            metadata = mapOf("source" to "test", "version" to "1.0")
+        )
+        val response = client.publish("test-topic", event, options)
+
+        assertEquals("test-event-id", response.id)
     }
 }

--- a/src/test/kotlin/dev/sailhouse/SailhouseSubscriberTest.kt
+++ b/src/test/kotlin/dev/sailhouse/SailhouseSubscriberTest.kt
@@ -1,0 +1,129 @@
+package dev.sailhouse
+
+import dev.sailhouse.models.*
+import io.ktor.client.engine.mock.*
+import io.ktor.http.*
+import kotlinx.coroutines.*
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SailhouseSubscriberTest {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        encodeDefaults = true
+    }
+
+    private var requestCount = 0
+    private val mockEngine = MockEngine { request ->
+        when {
+            request.url.encodedPath.contains("/pull") -> {
+                requestCount++
+                if (requestCount <= 2) {
+                    // Return an event for the first two requests
+                    val event = EventDto(
+                        id = "test-event-$requestCount",
+                        data = mapOf("message" to "Test message $requestCount"),
+                        queryableValue = "Test message $requestCount",
+                        timestamp = "2023-01-01T00:00:00Z"
+                    )
+                    respond(
+                        content = json.encodeToString(event),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                } else {
+                    // Return no content (no events) for subsequent requests
+                    respond(
+                        content = "",
+                        status = HttpStatusCode.NoContent
+                    )
+                }
+            }
+            request.url.encodedPath.contains("/events/") && request.method == HttpMethod.Post -> {
+                // ACK endpoint
+                respond(
+                    content = "",
+                    status = HttpStatusCode.OK
+                )
+            }
+            else -> {
+                respond(
+                    content = "Not found",
+                    status = HttpStatusCode.NotFound
+                )
+            }
+        }
+    }
+
+    private val config = SailhouseClientConfig(
+        baseUrl = "https://api.sailhouse.dev",
+        engine = mockEngine
+    )
+
+    private val client = SailhouseClient("test-api-key", config)
+
+    @Test
+    fun `test subscriber with single subscription`() = runBlocking {
+        val processedEvents = mutableListOf<String>()
+        
+        val subscriber = client.subscriber(SubscriberOptions(perSubscriptionProcessors = 1))
+        
+        subscriber.subscribe<Map<String, String>>("test-topic", "test-subscription") { event ->
+            processedEvents.add(event.event.id)
+        }
+
+        // Start subscriber in a coroutine and stop it after a short delay
+        val job = launch {
+            subscriber.start()
+        }
+
+        delay(100) // Let it process a few events
+        subscriber.stop()
+        job.cancel()
+
+        // Should have processed at least one event
+        assertEquals(true, processedEvents.isNotEmpty())
+    }
+
+    @Test
+    fun `test subscriber options`() {
+        val options = SubscriberOptions(perSubscriptionProcessors = 3)
+        val subscriber = client.subscriber(options)
+        
+        // Test that subscriber was created with the right options
+        // This is a basic test since we can't easily verify internal state
+        subscriber.subscribe<Map<String, String>>("test-topic", "test-subscription") { event ->
+            // Do nothing
+        }
+    }
+
+    @Test
+    fun `test multiple subscriptions`() = runBlocking {
+        val processedEvents = mutableListOf<String>()
+        
+        val subscriber = client.subscriber()
+        
+        subscriber.subscribe<Map<String, String>>("topic1", "sub1") { event ->
+            processedEvents.add("topic1-${event.event.id}")
+        }
+        
+        subscriber.subscribe<Map<String, String>>("topic2", "sub2") { event ->
+            processedEvents.add("topic2-${event.event.id}")
+        }
+
+        // Start subscriber in a coroutine and stop it after a short delay
+        val job = launch {
+            subscriber.start()
+        }
+
+        delay(100) // Let it process a few events
+        subscriber.stop()
+        job.cancel()
+
+        // Should have processed events from both subscriptions
+        assertEquals(true, processedEvents.isNotEmpty())
+    }
+}

--- a/src/test/kotlin/dev/sailhouse/WaitGroupsTest.kt
+++ b/src/test/kotlin/dev/sailhouse/WaitGroupsTest.kt
@@ -1,0 +1,89 @@
+package dev.sailhouse
+
+import dev.sailhouse.models.*
+import io.ktor.client.engine.mock.*
+import io.ktor.http.*
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WaitGroupsTest {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        encodeDefaults = true
+    }
+
+    private val mockEngine = MockEngine { request ->
+        when {
+            request.url.encodedPath == "/waitgroups/instances" -> {
+                val response = WaitGroupInstanceResponse(waitGroupInstanceId = "test-wg-instance")
+                respond(
+                    content = json.encodeToString(response),
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json")
+                )
+            }
+            request.url.encodedPath.contains("/topics/") && request.url.encodedPath.contains("/events") -> {
+                val response = PublishEventResponseDto(id = "test-event-id")
+                respond(
+                    content = json.encodeToString(response),
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json")
+                )
+            }
+            request.url.encodedPath.contains("/waitgroups/instances/") && 
+            request.url.encodedPath.contains("/events") -> {
+                respond(
+                    content = "",
+                    status = HttpStatusCode.OK
+                )
+            }
+            else -> {
+                respond(
+                    content = "Not found",
+                    status = HttpStatusCode.NotFound
+                )
+            }
+        }
+    }
+
+    private val config = SailhouseClientConfig(
+        baseUrl = "https://api.sailhouse.dev",
+        engine = mockEngine
+    )
+
+    private val client = SailhouseClient("test-api-key", config)
+
+    @Test
+    fun `test wait group creation and execution`() = runBlocking {
+        val events = listOf(
+            WaitGroupEvent(
+                topic = "orders",
+                body = mapOf("orderId" to "123", "status" to "created")
+            ),
+            WaitGroupEvent(
+                topic = "inventory",
+                body = mapOf("productId" to "456", "quantity" to -1)
+            )
+        )
+
+        val options = WaitOptions(ttl = "5m")
+
+        // This should not throw an exception
+        client.wait("orders", events, options)
+    }
+
+    @Test
+    fun `test publish with wait group instance id`() = runBlocking {
+        val event = mapOf("message" to "Test message")
+        val options = PublishEventOptions(
+            waitGroupInstanceId = "test-wg-instance"
+        )
+
+        val response = client.publish("test-topic", event, options)
+        assertEquals("test-event-id", response.id)
+    }
+}


### PR DESCRIPTION
- Metadata Support (commit 91828274) - Added metadata field to Event and EventDto classes
- Waitgroups (commit 0ac23c7) - Implemented wait() method and wait_group_instance_id support
- AdminClient (commit 950889d) - Created AdminClient for push subscription management
- Advanced Filters (commit aff688b) - Added complex filters, rate limits, and deduplication
- Long-running Subscribers (commit f4c1fbb) - Implemented SailhouseSubscriber pattern
- Push Verification (commit b5af32e) - Created HMAC verification utilities